### PR TITLE
Run tests and fix demo imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,15 @@ python start_unified_interface.py
 
 Open <http://localhost:5000> in your browser to configure and run a simulation.
 
+### Running the Example Scripts
+
+Demo scripts are located in the `examples/` directory. Run them from the project
+root so the `src` package can be discovered:
+
+```bash
+python examples/cue_system_demo.py
+```
+
 ## Running Tests
 
 This project uses `pytest`. To execute the test suite run:

--- a/examples/cue_system_demo.py
+++ b/examples/cue_system_demo.py
@@ -7,9 +7,11 @@ internal states and proximity to cue sources.
 """
 import sys
 import os
+from pathlib import Path
 
-# Add the src directory to the path so we can import our modules
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+# Add the project root to sys.path so we can import the ``src`` package
+project_root = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(project_root))
 
 from src.environment.cues import CueGenerator
 from src.utils.types import (


### PR DESCRIPTION
## Summary
- fix PYTHONPATH handling in cue_system_demo.py
- document how to run example scripts

## Testing
- `pytest -q`
- `python examples/cue_system_demo.py | head`

------
https://chatgpt.com/codex/tasks/task_e_683f7578dad08329b178bc315966bfe1