### PR TITLE
Add D3 map visualization with preview

### DIFF
--- a/src/visualization/static/js/dashboard.js
+++ b/src/visualization/static/js/dashboard.js
@@ -1,0 +1,144 @@
+// Dashboard map rendering and controls
+let layoutData = null;
+let agentLayer, buildingLayer, heatLayer;
+let svg, mainGroup;
+let xScale, yScale;
+let zoom;
+
+function initializeDashboard() {
+    svg = d3.select('#cityMap');
+    mainGroup = svg.append('g');
+    agentLayer = mainGroup.append('g').attr('id', 'agents');
+    buildingLayer = mainGroup.append('g').attr('id', 'buildings');
+    heatLayer = mainGroup.append('g').attr('id', 'heat');
+
+    zoom = d3.zoom().scaleExtent([0.5, 8]).on('zoom', (event) => {
+        mainGroup.attr('transform', event.transform);
+    });
+    svg.call(zoom);
+
+    document.getElementById('showAgents').addEventListener('click', () => toggleLayer(agentLayer, 'showAgents'));
+    document.getElementById('showBuildings').addEventListener('click', () => toggleLayer(buildingLayer, 'showBuildings'));
+    document.getElementById('showHeatMap').addEventListener('click', () => toggleLayer(heatLayer, 'showHeatMap'));
+
+    fetchLayout();
+    fetchRealtime();
+    setInterval(fetchRealtime, 2000);
+}
+
+function toggleLayer(layer, btnId) {
+    const btn = document.getElementById(btnId);
+    const active = btn.getAttribute('data-active') === 'true';
+    btn.setAttribute('data-active', active ? 'false' : 'true');
+    btn.classList.toggle('active', !active);
+    layer.style('display', active ? 'none' : 'block');
+}
+
+async function fetchLayout() {
+    const res = await fetch('/api/city-layout');
+    layoutData = await res.json();
+    setupScales();
+    renderLayout();
+}
+
+function setupScales() {
+    const {bounds} = layoutData;
+    xScale = d3.scaleLinear().domain([bounds.min_x, bounds.max_x]).range([0, parseInt(svg.attr('width'))]);
+    yScale = d3.scaleLinear().domain([bounds.min_y, bounds.max_y]).range([parseInt(svg.attr('height')), 0]);
+}
+
+function renderLayout() {
+    buildingLayer.selectAll('*').remove();
+
+    // Buildings
+    buildingLayer.selectAll('rect.building')
+        .data(layoutData.buildings)
+        .enter()
+        .append('rect')
+        .attr('class', 'building')
+        .attr('x', d => xScale(d.location.x) - 4)
+        .attr('y', d => yScale(d.location.y) - 4)
+        .attr('width', 8)
+        .attr('height', 8)
+        .attr('fill', '#888')
+        .attr('stroke', '#000')
+        .attr('stroke-width', 0.5);
+}
+
+async function fetchRealtime() {
+    const res = await fetch('/api/realtime-data');
+    const data = await res.json();
+    updateAgents(data.agents);
+    updateHeatMap(data.heat_map_data.stress);
+    updateTimeline(data.simulation_state);
+}
+
+function updateAgents(agents) {
+    const tooltip = d3.select('#agentTooltip');
+    const circles = agentLayer.selectAll('circle.agent').data(agents, d => d.id);
+
+    circles.enter()
+        .append('circle')
+        .attr('class', 'agent')
+        .attr('r', d => d.visual_properties.size)
+        .attr('fill', d => d.visual_properties.color)
+        .merge(circles)
+        .attr('cx', d => xScale(d.location.x))
+        .attr('cy', d => yScale(d.location.y))
+        .on('mouseover', (event, d) => {
+            tooltip.style('opacity', 1)
+                   .html(`Agent ${d.id}<br>Stress: ${d.state.stress.toFixed(2)}`)
+                   .style('left', (event.pageX + 10) + 'px')
+                   .style('top', (event.pageY - 20) + 'px');
+        })
+        .on('mouseout', () => tooltip.style('opacity', 0));
+
+    circles.exit().remove();
+}
+
+function updateHeatMap(cells) {
+    const color = d3.scaleSequential(d3.interpolateYlOrRd).domain([0, 1]);
+    const rects = heatLayer.selectAll('rect.heat').data(cells, d => `${d.x},${d.y}`);
+
+    rects.enter()
+        .append('rect')
+        .attr('class', 'heat')
+        .attr('width', 10)
+        .attr('height', 10)
+        .merge(rects)
+        .attr('x', d => xScale(d.x) - 5)
+        .attr('y', d => yScale(d.y) - 5)
+        .attr('fill', d => color(d.value))
+        .attr('opacity', 0.6);
+
+    rects.exit().remove();
+}
+
+function updateTimeline(state) {
+    const slider = document.getElementById('timelineSlider');
+    const span = document.getElementById('timelineValue');
+    if (!state || !slider) return;
+    const progress = state.time_info.round_progress + state.months_completed;
+    slider.value = progress;
+    span.textContent = `Month ${state.time_info.month} Round ${state.time_info.current_round}`;
+}
+
+async function exportMap() {
+    const layout = layoutData;
+    const res = await fetch('/api/realtime-data');
+    const realtime = await res.json();
+    const data = {layout, realtime};
+    const blob = new Blob([JSON.stringify(data, null, 2)], {type: 'application/json'});
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'map_snapshot.json';
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+}
+
+if (typeof module !== 'undefined') {
+    module.exports = { initializeDashboard };
+}

--- a/src/visualization/static/js/setup_wizard.js
+++ b/src/visualization/static/js/setup_wizard.js
@@ -180,6 +180,11 @@ class SetupWizard {
                                     <label class="btn btn-outline-primary" for="sizeLarge">Large</label>
                                 </div>
                             </div>
+
+                            <div class="mb-3">
+                                <label class="form-label">Map Preview</label>
+                                <div id="cityMapPreview" class="border p-2" style="height: 200px;"></div>
+                            </div>
                         </div>
                     </div>
                 </div>
@@ -260,6 +265,7 @@ class SetupWizard {
         
         this.setupCityConfigurationHandlers();
         this.updateCitySummary();
+        this.renderCityPreview();
     }
     
     setupCityConfigurationHandlers() {
@@ -315,6 +321,40 @@ class SetupWizard {
         if (totalBuildingsEl) totalBuildingsEl.textContent = totalBuildings;
         if (housingCapacityEl) housingCapacityEl.textContent = housingCapacity;
         if (employmentCapacityEl) employmentCapacityEl.textContent = employmentCapacity;
+
+        this.renderCityPreview();
+    }
+
+    renderCityPreview() {
+        const container = d3.select('#cityMapPreview');
+        if (container.empty()) return;
+        container.selectAll('*').remove();
+
+        const width = parseInt(container.style('width'));
+        const height = parseInt(container.style('height'));
+        const svg = container.append('svg').attr('width', width).attr('height', height);
+
+        const size = app.state.configuration.citySize || 'medium';
+        const grid = size === 'small' ? 20 : size === 'large' ? 50 : 30;
+        const scaleX = d3.scaleLinear().domain([0, grid]).range([0, width]);
+        const scaleY = d3.scaleLinear().domain([0, grid]).range([0, height]);
+
+        const cells = [];
+        for (let x = 0; x < grid; x++) {
+            for (let y = 0; y < grid; y++) {
+                cells.push({x, y});
+            }
+        }
+
+        svg.selectAll('rect').data(cells).enter()
+            .append('rect')
+            .attr('x', d => scaleX(d.x))
+            .attr('y', d => scaleY(d.y))
+            .attr('width', scaleX(1) - scaleX(0))
+            .attr('height', scaleY(1) - scaleY(0))
+            .attr('fill', '#2d3748')
+            .attr('stroke', '#444')
+            .attr('stroke-width', 0.5);
     }
     
     showPopulationConfigurationStep(container) {

--- a/src/visualization/templates/dashboard.html
+++ b/src/visualization/templates/dashboard.html
@@ -320,6 +320,16 @@
                     <button class="btn btn-outline-info btn-sm w-100" id="requestUpdate">
                         <i class="fas fa-sync-alt"></i> Manual Update
                     </button>
+
+                    <div class="mt-3">
+                        <label for="timelineSlider" class="form-label">Timeline</label>
+                        <input type="range" class="form-range" id="timelineSlider" min="0" max="100" value="0">
+                        <div class="small text-muted" id="timelineValue"></div>
+                    </div>
+
+                    <button class="btn btn-outline-primary btn-sm w-100 mt-2" id="exportMap">
+                        <i class="fas fa-download"></i> Export Map Snapshot
+                    </button>
                 </div>
 
                 <!-- Quick Stats -->
@@ -363,14 +373,14 @@
     <script src="https://d3js.org/d3.v7.min.js"></script>
 
     <!-- Custom JavaScript -->
+    <script src="{{ url_for('static', filename='js/dashboard.js') }}"></script>
     <script>
-        // Dashboard JavaScript will be loaded here
         document.addEventListener('DOMContentLoaded', function() {
             console.log('Simulacra Dashboard Loaded');
             initializeDashboard();
+            const exportBtn = document.getElementById('exportMap');
+            if (exportBtn) exportBtn.addEventListener('click', exportMap);
         });
     </script>
-
-    <script src="{{ url_for('static', filename='js/dashboard.js') }}"></script>
 </body>
-</html> 
+</html>


### PR DESCRIPTION
## Summary
- implement D3-based city map rendering via new `dashboard.js`
- add timeline and export controls to dashboard page
- integrate map preview in setup wizard

## Testing
- `pip install numpy`
- `pip install pandas`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f7f604d0c8329a1dbb95e2ceb60a1