### PR TITLE
Render district polygons and building types

### DIFF
--- a/src/visualization/templates/dashboard.html
+++ b/src/visualization/templates/dashboard.html
@@ -268,9 +268,13 @@
                         <!-- City visualization will be rendered here -->
                     </svg>
                     
-                    <!-- Heat Map Legend -->
+                    <!-- Map Legend -->
                     <div class="heat-map-legend" id="heatMapLegend" style="display: none;">
-                        <h6 class="text-white mb-2">Heat Map</h6>
+                        <h6 class="text-white mb-2">Legend</h6>
+                        <div id="districtLegend"></div>
+                        <hr class="text-white my-1" />
+                        <div id="buildingLegend"></div>
+                        <hr class="text-white my-1" />
                         <div class="legend-item">
                             <div class="legend-color" style="background: linear-gradient(to right, #00ff00, #ffff00, #ff0000);"></div>
                             <small>Stress Level</small>


### PR DESCRIPTION
## Summary
- visualize district boundaries in dashboard map
- color code building symbols by type
- add legend sections for districts and buildings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f86b5586c8329b31647ac6874abe9