### PR TITLE
Integrate pause/resume API controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Simulacra is an agent-based urban simulation platform focused on behavioral econ
 - **Population generation** utilities for realistic or custom agent distributions
 - **Analytics** module collecting detailed agent and population metrics
 - **Real-time dashboard** and web-based setup wizard built with Flask and Socket.IO
+- **Threaded simulation** option for faster agent updates
+- **Pause/resume controls** to manage running simulations
 
 ## Installation
 

--- a/src/visualization/visualization_server.py
+++ b/src/visualization/visualization_server.py
@@ -101,10 +101,10 @@ class VisualizationServer:
                 simulation = self.data_streamer.simulation
                 
                 if action == 'pause':
-                    # Note: Would need to implement pause functionality in simulation
+                    simulation.pause()
                     return jsonify({'status': 'paused'})
                 elif action == 'resume':
-                    # Note: Would need to implement resume functionality
+                    simulation.resume()
                     return jsonify({'status': 'running'})
                 elif action == 'stop':
                     simulation.stop()

--- a/tests/test_simulation_performance.py
+++ b/tests/test_simulation_performance.py
@@ -1,0 +1,33 @@
+import unittest
+from src.simulation.simulation import Simulation, SimulationConfig
+from src.agents.agent import Agent
+from src.environment.city import City
+from src.environment.district import District
+from src.environment.plot import Plot
+from src.utils.types import PlotID, DistrictID, Coordinate, DistrictWealth
+
+class TestSimulationControl(unittest.TestCase):
+    def setUp(self):
+        plot = Plot(id=PlotID('p1'), location=Coordinate((0.0, 0.0)), district_id=DistrictID('d1'))
+        district = District(id=DistrictID('d1'), name='D1', wealth_level=DistrictWealth.WORKING_CLASS, plots=[plot])
+        self.city = City(name='TestCity', districts=[district])
+
+    def test_pause_resume_flags(self):
+        sim = Simulation(self.city, SimulationConfig(max_months=1, rounds_per_month=1, enable_logging=False))
+        sim.is_running = True
+        sim.pause()
+        self.assertTrue(sim.is_paused)
+        sim.resume()
+        self.assertFalse(sim.is_paused)
+
+    def test_threaded_round(self):
+        config = SimulationConfig(max_months=1, rounds_per_month=1, enable_logging=False, use_threading=True, num_threads=2)
+        sim = Simulation(self.city, config)
+        sim.add_agent(Agent.create_random())
+        sim.is_running = True
+        stats = sim.run_single_month()
+        self.assertEqual(stats.month, 2)
+
+if __name__ == '__main__':
+    unittest.main()
+

--- a/tests/test_time_management.py
+++ b/tests/test_time_management.py
@@ -309,10 +309,11 @@ class TestSimulationIntegration(unittest.TestCase):
             simulation.add_agent(agent)
             
         state = simulation.get_simulation_state()
-        
+
         self.assertEqual(state['total_agents'], 3)
         self.assertEqual(state['months_completed'], 0)
         self.assertFalse(state['is_running'])
+        self.assertFalse(state['is_paused'])
         
     def test_agent_summary(self):
         """Test agent summary statistics."""

--- a/tests/test_visualization_server.py
+++ b/tests/test_visualization_server.py
@@ -1,0 +1,39 @@
+import unittest
+from src.simulation.simulation import Simulation, SimulationConfig
+from src.environment.city import City
+from src.environment.district import District
+from src.environment.plot import Plot
+from src.utils.types import PlotID, DistrictID, Coordinate, DistrictWealth
+from src.analytics.metrics import MetricsCollector
+from src.visualization.data_streamer import DataStreamer
+from src.visualization.visualization_server import VisualizationServer
+
+class TestSimulationControlAPI(unittest.TestCase):
+    def setUp(self):
+        plot = Plot(id=PlotID('p1'), location=Coordinate((0.0, 0.0)), district_id=DistrictID('d1'))
+        district = District(id=DistrictID('d1'), name='D1', wealth_level=DistrictWealth.WORKING_CLASS, plots=[plot])
+        city = City(name='TestCity', districts=[district])
+        self.simulation = Simulation(city, SimulationConfig(max_months=1, rounds_per_month=1, enable_logging=False))
+        self.simulation.is_running = True
+        streamer = DataStreamer(self.simulation, MetricsCollector())
+        self.server = VisualizationServer(streamer)
+        self.client = self.server.app.test_client()
+
+    def test_pause_resume_and_stop(self):
+        resp = self.client.post('/api/simulation-control', json={'action': 'pause'})
+        self.assertEqual(resp.status_code, 200)
+        self.assertTrue(self.simulation.is_paused)
+        self.assertEqual(resp.get_json()['status'], 'paused')
+
+        resp = self.client.post('/api/simulation-control', json={'action': 'resume'})
+        self.assertEqual(resp.status_code, 200)
+        self.assertFalse(self.simulation.is_paused)
+        self.assertEqual(resp.get_json()['status'], 'running')
+
+        resp = self.client.post('/api/simulation-control', json={'action': 'stop'})
+        self.assertEqual(resp.status_code, 200)
+        self.assertFalse(self.simulation.is_running)
+        self.assertEqual(resp.get_json()['status'], 'stopped')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- expose `pause()` and `resume()` in visualization server
- report `is_paused` from `Simulation.get_simulation_state`
- extend time management test
- add new test for the visualization control endpoint

## Testing
- `pytest tests/test_visualization_server.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840b9afc29c8329b98b5d96a2d25e1f