### PR TITLE
Add desktop UI extras and launcher script entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ Optional visualization extras can be installed with:
 pip install .[visualization]
 ```
 
+For the desktop launcher, install the additional PyQt packages:
+
+```bash
+pip install .[desktop]
+```
+
 ## Quick Start
 
 Launch the unified interface with the setup wizard and dashboard:
@@ -37,11 +43,10 @@ python start_unified_interface.py
 Open <http://localhost:5000> in your browser to configure and run a simulation.
 
 Alternatively, you can launch a desktop window that embeds the interface so no
-external browser is required. Install the optional PyQt dependencies and run:
+external browser is required. After installing the `desktop` extras, run:
 
 ```bash
-pip install PyQt6 PyQt6-WebEngine
-python start_local_interface.py
+simulacra-desktop
 ```
 
 ### Running the Example Scripts

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,5 +36,14 @@ visualization = [
   "gevent-websocket>=0.10"
 ]
 
+desktop = [
+  "PyQt6>=6.0",
+  "PyQt6-WebEngine>=6.0"
+]
+
+[project.scripts]
+simulacra-desktop = "start_local_interface:main"
+simulacra-unified = "start_unified_interface:main"
+
 [project.urls]
 Homepage = "https://example.com"

--- a/tests/test_desktop_ui.py
+++ b/tests/test_desktop_ui.py
@@ -1,0 +1,12 @@
+import importlib
+import pytest
+
+
+def test_start_local_interface_import() -> None:
+    """Ensure the desktop launcher module can be imported when PyQt is present."""
+    try:
+        module = importlib.import_module("start_local_interface")
+    except Exception as exc:  # pragma: no cover - environment may lack Qt libs
+        pytest.skip(f"PyQt unavailable: {exc}")
+        return
+    assert hasattr(module, "main")


### PR DESCRIPTION
## Summary
- document installing the `desktop` extras
- add `desktop` optional dependencies and console scripts
- test importing the desktop launcher

## Testing
- `flake8 src tests`
- `mypy src` *(fails: 195 errors)*
- `pytest -q`
- `sphinx-build docs docs/_build` *(fails: config directory doesn't contain a conf.py file)*

------
https://chatgpt.com/codex/tasks/task_e_6841021857d48329ae2710534ce09d7e