### PR TITLE
Handle missing plot type in Plot repr

### DIFF
--- a/src/simulacra/environment/plot.py
+++ b/src/simulacra/environment/plot.py
@@ -38,7 +38,9 @@ class Plot:
         return self.building is not None
 
     def __repr__(self) -> str:
+        """Return a human-readable representation for debugging."""
+        plot_type_name = self.plot_type.name if self.plot_type is not None else "UNKNOWN"
         return (
-            f"Plot(id={self.id}, type={self.plot_type.name}, "
+            f"Plot(id={self.id}, type={plot_type_name}, "
             f"loc={self.location}, occupied={self.is_occupied()})"
-        ) 
+        )

--- a/tests/test_environment_plot.py
+++ b/tests/test_environment_plot.py
@@ -1,0 +1,29 @@
+"""Tests for the Plot class in the environment module."""
+from simulacra.environment.plot import Plot
+from simulacra.utils.types import PlotID, DistrictID, Coordinate, PlotType
+
+
+def test_plot_repr_handles_missing_optional_fields() -> None:
+    """Ensure __repr__ does not raise when optional data is absent."""
+    plot = Plot()
+
+    result = repr(plot)
+
+    assert "type=UNKNOWN" in result
+    assert "occupied=False" in result
+
+
+def test_plot_repr_includes_provided_information() -> None:
+    """The representation should include provided identifiers and location."""
+    plot = Plot(
+        plot_id=PlotID("plot-1"),
+        location=Coordinate((1.0, 2.0)),
+        district=DistrictID("district-1"),
+        plot_type=PlotType.PUBLIC_SPACE,
+    )
+
+    result = repr(plot)
+
+    assert "Plot(id=plot-1" in result
+    assert "type=PUBLIC_SPACE" in result
+    assert "loc=(1.0, 2.0)" in result


### PR DESCRIPTION
## Summary
- avoid raising an AttributeError in `Plot.__repr__` when a plot type is not set
- document the helper and add regression tests covering repr output with and without optional data

## Testing
- pytest
- flake8 src tests *(fails due to numerous pre-existing lint issues in the repository)*
- mypy src
- sphinx-build docs/ docs/_build/


------
https://chatgpt.com/codex/tasks/task_e_68ca2e1477148329be5440b4fd5e79b1