### PR TITLE
Improve setup automation with conda support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,15 +23,23 @@ Simulacra is an agent-based urban simulation platform focused on behavioral econ
 
 ### 2. One-command bootstrap (recommended)
 
-Run the cross-platform helper to create a `.venv` directory and install Simulacra with the visualization and desktop extras.
+Run the cross-platform helper to create a managed environment and install Simulacra with the visualization and desktop extras. By default it builds a `.venv` folder, upgrades `pip`, installs the requested extras and prints the exact activation command for your shell. It also refuses to run with an unsupported Python version and warns if you already activated another environment so you always know what is happening.
 
-| Platform | Command |
+| Scenario | Command |
 | --- | --- |
 | Windows (PowerShell) | `py setup_simulacra.py` |
 | Windows (Command Prompt) | `python setup_simulacra.py` |
 | macOS / Linux | `python3 setup_simulacra.py` |
+| Any platform, manage everything inside conda | `python setup_simulacra.py --use-conda` |
 
-The script accepts optional flags such as `--force-recreate` to rebuild the virtual environment, `--extras` to customise installed extras, and `--include-dev` to pull in linting/test tooling. Run `python setup_simulacra.py --help` for the complete list.
+Commonly used options:
+
+- `--force-recreate` – rebuild the environment from scratch (works for both venv and conda).
+- `--extras visualization analytics` – install only selected optional extras.
+- `--include-dev` – add linting, typing and documentation tooling.
+- `--conda-env simulacra --conda-python 3.11` – customise the conda environment name and Python version.
+
+Run `python setup_simulacra.py --help` for the complete list, including automation-friendly options.
 
 ### 3. Activate the virtual environment
 
@@ -60,6 +68,15 @@ If you cannot run the helper script, create a virtual environment manually and i
 ```bash
 python -m venv .venv
 source .venv/bin/activate  # or the Windows equivalent above
+python -m pip install --upgrade pip
+python -m pip install -e .[desktop,visualization]
+```
+
+Prefer conda? Create an environment and install the package directly:
+
+```bash
+conda create --name simulacra python=3.10
+conda activate simulacra
 python -m pip install --upgrade pip
 python -m pip install -e .[desktop,visualization]
 ```

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -31,22 +31,42 @@ project folder.
 
 ## 3. Run the bootstrap helper
 
-Launch the cross-platform setup script. It creates a `.venv` directory and
-installs the default optional extras (`desktop` and `visualization`).
+Launch the cross-platform setup script. It creates a `.venv` directory by
+default, upgrades `pip`, installs the default optional extras (`desktop` and
+`visualization`), and prints clear activation instructions tailored to your
+shell. The helper refuses to proceed if it detects an unsupported Python
+version and warns if another environment is already active, so you always know
+what it is about to modify.
 
 | Platform | Command |
 | --- | --- |
 | Windows (PowerShell) | `py setup_simulacra.py` |
 | Windows (Command Prompt) | `python setup_simulacra.py` |
 | macOS / Linux | `python3 setup_simulacra.py` |
+| Any platform (manage everything inside conda) | `python setup_simulacra.py --use-conda` |
 
 Commonly used flags:
 
 - `--force-recreate`: delete and rebuild the virtual environment if it already exists.
 - `--extras visualization`: install only selected extras (space separated list).
 - `--include-dev`: add linting, testing and documentation tooling.
+- `--conda-env simulacra`: pick a custom environment name when using conda.
+- `--conda-python 3.11`: create the conda environment with a specific Python
+  version (defaults to 3.10).
 
 Run `python setup_simulacra.py --help` to see every option.
+
+> 🟦 **Prefer a conda workflow?**
+>
+> The helper automates conda just as well:
+>
+> ```bash
+> python setup_simulacra.py --use-conda --conda-env simulacra
+> ```
+>
+> This creates (or reuses) the named environment, ensures it runs Python 3.10+
+> and installs the requested extras. When the script finishes, activate it with
+> `conda activate simulacra` and you are ready to go.
 
 ## 4. Activate the virtual environment
 
@@ -88,6 +108,15 @@ If you prefer to manage the environment yourself:
 ```bash
 python -m venv .venv
 source .venv/bin/activate  # or Windows equivalent
+python -m pip install --upgrade pip
+python -m pip install -e .[desktop,visualization]
+```
+
+For conda users:
+
+```bash
+conda create --name simulacra python=3.10
+conda activate simulacra
 python -m pip install --upgrade pip
 python -m pip install -e .[desktop,visualization]
 ```

--- a/setup_simulacra.py
+++ b/setup_simulacra.py
@@ -1,7 +1,8 @@
 """Cross-platform setup helper for the Simulacra project.
 
 This script creates (or reuses) a virtual environment and installs the
-requested optional dependency groups.  It is intended to replace the
+requested optional dependency groups.  It can also bootstrap a conda
+environment when ``--use-conda`` is supplied.  The helper replaces the
 POSIX-only shell script so new contributors – especially those on
 Windows – can prepare the project with a single command:
 
@@ -13,13 +14,14 @@ Run ``python setup_simulacra.py --help`` for the full list of options.
 from __future__ import annotations
 
 import argparse
+import json
 import os
 import platform
 import shutil
 import subprocess
 import sys
 from pathlib import Path
-from typing import Iterable, List
+from typing import Iterable, List, Optional, Tuple
 
 
 def parse_args() -> argparse.Namespace:
@@ -52,6 +54,30 @@ def parse_args() -> argparse.Namespace:
         "--force-recreate",
         action="store_true",
         help="Delete any existing virtual environment before creating a new one.",
+    )
+    parser.add_argument(
+        "--use-conda",
+        action="store_true",
+        help=(
+            "Create or reuse a conda environment instead of using python -m venv."
+            " Requires the conda command to be available."
+        ),
+    )
+    parser.add_argument(
+        "--conda-env",
+        default="simulacra",
+        help=(
+            "Name of the conda environment to manage when --use-conda is provided."
+            " (default: simulacra)"
+        ),
+    )
+    parser.add_argument(
+        "--conda-python",
+        default="3.10",
+        help=(
+            "Python version to install when creating a conda environment."
+            " (default: 3.10)"
+        ),
     )
     return parser.parse_args()
 
@@ -100,6 +126,153 @@ def venv_python(venv_path: Path) -> Path:
     return python_path
 
 
+def conda_available() -> bool:
+    return shutil.which("conda") is not None
+
+
+def ensure_conda_available() -> None:
+    if not conda_available():
+        raise SystemExit(
+            "The 'conda' command was not found. Install Miniconda/Anaconda or "
+            "run without --use-conda."
+        )
+
+
+def conda_env_exists(env_name: str) -> bool:
+    try:
+        output = subprocess.check_output(
+            ["conda", "env", "list", "--json"], text=True
+        )
+        envs = json.loads(output).get("envs", [])
+    except (subprocess.CalledProcessError, json.JSONDecodeError) as error:
+        raise SystemExit("Unable to query conda environments.") from error
+
+    for env_path in envs:
+        path = Path(env_path)
+        if path.name == env_name or path == Path(env_name):
+            return True
+    return False
+
+
+def remove_conda_env(env_name: str) -> None:
+    subprocess.check_call(["conda", "env", "remove", "--yes", "--name", env_name])
+
+
+def create_conda_env(env_name: str, python_version: str) -> None:
+    print(
+        f"Creating conda environment '{env_name}' with Python {python_version} …"
+    )
+    subprocess.check_call(
+        ["conda", "create", "--yes", "--name", env_name, f"python={python_version}"]
+    )
+
+
+def conda_python_path(env_name: str) -> Path:
+    python_location = subprocess.check_output(
+        [
+            "conda",
+            "run",
+            "-n",
+            env_name,
+            "python",
+            "-c",
+            "import sys; print(sys.executable)",
+        ],
+        text=True,
+    ).strip()
+    path = Path(python_location)
+    if not path.exists():
+        raise SystemExit(
+            f"Unable to locate python executable for conda environment '{env_name}'."
+        )
+    return path
+
+
+def ensure_conda_python_version(env_name: str) -> Tuple[int, int]:
+    version = subprocess.check_output(
+        [
+            "conda",
+            "run",
+            "-n",
+            env_name,
+            "python",
+            "-c",
+            "import sys; print('.'.join(map(str, sys.version_info[:2])))",
+        ],
+        text=True,
+    ).strip()
+    try:
+        major_str, minor_str = version.split(".")[:2]
+        major, minor = int(major_str), int(minor_str)
+    except ValueError as error:
+        raise SystemExit(
+            f"Unexpected Python version string for conda env '{env_name}': {version}"
+        ) from error
+    if (major, minor) < (3, 10):
+        raise SystemExit(
+            "Simulacra requires Python >= 3.10. The conda environment "
+            f"'{env_name}' is using {version}. Run with --force-recreate to rebuild it "
+            "with a newer Python interpreter."
+        )
+    return major, minor
+
+
+def prepare_conda_environment(
+    env_name: str, python_version: str, force_recreate: bool
+) -> Path:
+    if force_recreate and conda_env_exists(env_name):
+        print(f"Removing existing conda environment '{env_name}'")
+        remove_conda_env(env_name)
+
+    if conda_env_exists(env_name):
+        print(f"Reusing conda environment '{env_name}'")
+    else:
+        create_conda_env(env_name, python_version)
+
+    major, minor = ensure_conda_python_version(env_name)
+    print(f"Conda environment Python version: {major}.{minor}")
+    return conda_python_path(env_name)
+
+
+def warn_about_active_environment(
+    use_conda: bool, target_conda_env: Optional[str]
+) -> None:
+    if os.environ.get("VIRTUAL_ENV"):
+        if use_conda:
+            print(
+                "ℹ️  Detected an active virtual environment. Conda will create its "
+                "own environment. Run 'deactivate' first if you prefer a clean "
+                "shell."
+            )
+        else:
+            print(
+                "ℹ️  Detected an active virtual environment. The helper ignores it "
+                "and manages the environment requested here."
+            )
+
+    conda_prefix = os.environ.get("CONDA_PREFIX")
+    if conda_prefix:
+        active_name = os.environ.get("CONDA_DEFAULT_ENV", conda_prefix)
+        if use_conda:
+            if target_conda_env and active_name == target_conda_env:
+                print(
+                    f"ℹ️  Conda environment '{active_name}' is already active."
+                    " Dependencies will be installed in place."
+                )
+            else:
+                hint = target_conda_env or "the target environment"
+                print(
+                    f"ℹ️  Detected active conda environment '{active_name}'. The "
+                    f"helper will install into {hint}."
+                )
+        else:
+            print(
+                f"ℹ️  Detected active conda environment '{active_name}'. Pass "
+                "--use-conda to install dependencies inside conda instead of a "
+                ".venv."
+            )
+
+
 def normalize_extras(extras: Iterable[str], include_dev: bool) -> List[str]:
     selected = [extra.strip() for extra in extras if extra.strip()]
     if include_dev:
@@ -132,7 +305,7 @@ def install_dependencies(python_path: Path, extras: List[str]) -> None:
     run_step("Installing project dependencies", ["-m", "pip", "install", "-e", target])
 
 
-def activation_instructions(venv_path: Path) -> str:
+def venv_activation_instructions(venv_path: Path) -> str:
     """Return a human-friendly activation hint for the virtual environment."""
 
     if platform.system() == "Windows":
@@ -148,28 +321,52 @@ def activation_instructions(venv_path: Path) -> str:
     return f"Unix/macOS shell: `source {activate_path}`"
 
 
+def conda_activation_instructions(env_name: str) -> str:
+    return (
+        f"Activate the environment in any shell with: `conda activate {env_name}`"
+    )
+
+
 def main() -> None:
-    ensure_python_version()
     args = parse_args()
+
+    if args.use_conda:
+        ensure_conda_available()
+    else:
+        ensure_python_version()
 
     root = project_root()
     os.chdir(root)
 
-    venv_arg = Path(args.venv)
-    venv_path = venv_arg if venv_arg.is_absolute() else (root / venv_arg).resolve()
-    if args.force_recreate:
-        print(f"Removing existing virtual environment at {venv_path}")
-        recreate_venv(venv_path)
-
-    create_venv(venv_path)
-    python_path = venv_python(venv_path)
+    warn_about_active_environment(args.use_conda, args.conda_env if args.use_conda else None)
 
     extras = normalize_extras(args.extras, args.include_dev)
+
+    if args.use_conda:
+        python_path = prepare_conda_environment(
+            args.conda_env, args.conda_python, args.force_recreate
+        )
+        activation_hint = conda_activation_instructions(args.conda_env)
+    else:
+        venv_arg = Path(args.venv)
+        venv_path = (
+            venv_arg if venv_arg.is_absolute() else (root / venv_arg).resolve()
+        )
+        if args.force_recreate:
+            print(f"Removing existing virtual environment at {venv_path}")
+            recreate_venv(venv_path)
+
+        create_venv(venv_path)
+        python_path = venv_python(venv_path)
+        activation_hint = venv_activation_instructions(
+            venv_arg if not venv_arg.is_absolute() else venv_path
+        )
+
     install_dependencies(python_path, extras)
 
     print("\n✅ Simulacra environment ready.")
-    print("To activate the virtual environment run:")
-    print(activation_instructions(venv_arg if not venv_arg.is_absolute() else venv_path))
+    print("To activate the environment run:")
+    print(activation_hint)
     print(
         "\nNext steps:\n"
         "  1. Activate the environment.\n"


### PR DESCRIPTION
## Summary
- add conda environment management, warnings, and activation guidance to the setup helper
- document the new helper capabilities and include idiot-proof conda/manual instructions in README and docs

## Testing
- pytest
- flake8 src tests
- mypy src
- sphinx-build docs/ docs/_build/

------
https://chatgpt.com/codex/tasks/task_e_68ca5a87f1208329a7da40ce48cfe3bc